### PR TITLE
Added functionality to deactivate/reactivate miniTip on an element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [miniTip jQuery plugin](http://minijs.com/plugins/6/tip) [![Build Status](https://secure.travis-ci.org/miniJs/miniTip.png?branch=master)](http://travis-ci.org/patrickayoup/miniTip)
+# [miniTip jQuery plugin](http://minijs.com/plugins/6/tip) [![Build Status](https://secure.travis-ci.org/miniJs/miniTip.png?branch=master)](http://travis-ci.org/matthieua/miniTip)
 
 miniTip is very basic but powerful tooltip jQuery plugin that allows you to show tooltips on a page at any time and it just works!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [miniTip jQuery plugin](http://minijs.com/plugins/6/tip) [![Build Status](https://secure.travis-ci.org/miniJs/miniTip.png?branch=master)](http://travis-ci.org/matthieua/miniTip)
+# [miniTip jQuery plugin](http://minijs.com/plugins/6/tip) [![Build Status](https://secure.travis-ci.org/miniJs/miniTip.png?branch=master)](http://travis-ci.org/patrickayoup/miniTip)
 
 miniTip is very basic but powerful tooltip jQuery plugin that allows you to show tooltips on a page at any time and it just works!
 

--- a/js/miniTip.coffee
+++ b/js/miniTip.coffee
@@ -200,6 +200,47 @@ jQuery ->
                   setState 'hidden'
             )
 
+
+        @activate = ->
+          if @getSetting('event') is 'hover'
+              # on hover
+              # keep track of the hover state
+              _hover = false
+
+              mouseEnterEventHandler = =>
+                _hover = true
+
+                @updatePosition()
+                setTimeout(=>
+                    @show() if _hover
+                , @getSetting 'delay')
+
+              mouseLeaveEventHandler = =>
+                _hover = false
+                @hide()
+
+              # attach the hover events to the element
+              @$element.hover( mouseEnterEventHandler, mouseLeaveEventHandler)
+          else
+              # on click
+              clickEventHandler = =>
+                @updatePosition()
+                @show()
+                window.setTimeout(=>
+                    @hide()
+                , @getSetting 'delay')
+
+              @$element.bind('click', clickEventHandler)
+
+        #unbinds the event handlers.
+        @deactivate = ->
+          if @getSetting('event') is 'hover'
+              @$element.unbind('mouseenter', mouseEnterEventHandler)
+              @$element.unbind('mouseleave', mouseLeaveEventHandler)
+          else
+              @$element.unbind('click', clickEventHandler)
+
+
         # init function
         @init = ->
             # merge options and default settings
@@ -241,36 +282,7 @@ jQuery ->
             # set animate properties
             showAnimateProperties = $.extend showAnimateProperties, @getSetting('showAnimateProperties')
             hideAnimateProperties = $.extend hideAnimateProperties, @getSetting('hideAnimateProperties')
-            
-            if @getSetting('event') is 'hover'
-                # on hover
-                # keep track of the hover state
-                _hover = false
-
-                mouseEnterEventHandler = =>
-                  _hover = true
-
-                  @updatePosition()
-                  setTimeout(=>
-                      @show() if _hover
-                  , @getSetting 'delay')
-
-                mouseLeaveEventHandler = =>
-                  _hover = false
-                  @hide()
-
-                # attach the hover events to the element
-                @$element.hover( mouseEnterEventHandler, mouseLeaveEventHandler)
-            else
-                # on click
-                clickEventHandler = =>
-                  @updatePosition()
-                  @show()
-                  window.setTimeout(=>
-                      @hide()
-                  , @getSetting 'delay')
-
-                @$element.bind('click', clickEventHandler)
+            @activate()
         # end init function
 
         # initialise the plugin

--- a/js/miniTip.coffee
+++ b/js/miniTip.coffee
@@ -36,6 +36,11 @@ jQuery ->
 
         ## private variables
 
+        # event handlers
+        mouseEnterEventHandler = null
+        mouseLeaveEventHandler = null
+        clickEventHandler = null
+
         # miniTip title
         content = ''
 
@@ -114,6 +119,13 @@ jQuery ->
         # get particular plugin setting
         @getSetting = (settingKey) ->
           @settings[settingKey]
+
+        # Get event handler
+        @getEventHandler = ->
+          if @getSetting('event') is 'hover'
+            return {mouseEnter: mouseEnterEventHandler, mouseLeave: mouseLeaveEventHandler}
+          else
+            return {click: clickEventHandler}
 
         # call one of the plugin setting functions
         @callSettingFunction = (functionName) ->
@@ -235,27 +247,30 @@ jQuery ->
                 # keep track of the hover state
                 _hover = false
 
+                mouseEnterEventHandler = =>
+                  _hover = true
+
+                  @updatePosition()
+                  setTimeout(=>
+                      @show() if _hover
+                  , @getSetting 'delay')
+
+                mouseLeaveEventHandler = =>
+                  _hover = false
+                  @hide()
+
                 # attach the hover events to the element
-                @$element.hover((=>
-                    _hover = true
-                  
-                    @updatePosition()
-                    setTimeout(=>
-                        @show() if _hover
-                    , @getSetting 'delay')
-                ), (=>
-                    _hover = false
-                    @hide()
-                ))
+                @$element.hover( mouseEnterEventHandler, mouseLeaveEventHandler)
             else
                 # on click
-                @$element.bind('click', =>
-                    @updatePosition()
-                    @show()
-                    window.setTimeout(=>
-                        @hide()
-                    , @getSetting 'delay')
-                )
+                clickEventHandler = =>
+                  @updatePosition()
+                  @show()
+                  window.setTimeout(=>
+                      @hide()
+                  , @getSetting 'delay')
+
+                @$element.bind('click', clickEventHandler)
         # end init function
 
         # initialise the plugin

--- a/js/miniTip.coffee
+++ b/js/miniTip.coffee
@@ -41,6 +41,8 @@ jQuery ->
         mouseLeaveEventHandler = null
         clickEventHandler = null
 
+        activated = true
+
         # miniTip title
         content = ''
 
@@ -119,6 +121,9 @@ jQuery ->
         # get particular plugin setting
         @getSetting = (settingKey) ->
           @settings[settingKey]
+
+        @isActivated = ->
+          activated
 
         # Get event handler
         @getEventHandler = ->
@@ -232,6 +237,8 @@ jQuery ->
 
               @$element.bind('click', clickEventHandler)
 
+          activated = true
+
         #unbinds the event handlers.
         @deactivate = ->
           if @getSetting('event') is 'hover'
@@ -239,6 +246,8 @@ jQuery ->
               @$element.unbind('mouseleave', mouseLeaveEventHandler)
           else
               @$element.unbind('click', clickEventHandler)
+
+          activated = false
 
 
         # init function

--- a/js/miniTip.js
+++ b/js/miniTip.js
@@ -1,7 +1,7 @@
 
 jQuery(function() {
   $.miniTip = function(element, options) {
-    var content, getArrowCss, hideAnimateProperties, miniTipCss, setState, showAnimateProperties,
+    var clickEventHandler, content, getArrowCss, hideAnimateProperties, miniTipCss, mouseEnterEventHandler, mouseLeaveEventHandler, setState, showAnimateProperties,
       _this = this;
     this.defaults = {
       position: 'top',
@@ -24,6 +24,9 @@ jQuery(function() {
       onHide: function() {},
       onHidden: function() {}
     };
+    mouseEnterEventHandler = null;
+    mouseLeaveEventHandler = null;
+    clickEventHandler = null;
     content = '';
     miniTipCss = {
       display: 'none',
@@ -118,6 +121,18 @@ jQuery(function() {
     };
     this.getSetting = function(settingKey) {
       return this.settings[settingKey];
+    };
+    this.getEventHandler = function() {
+      if (this.getSetting('event') === 'hover') {
+        return {
+          mouseEnter: mouseEnterEventHandler,
+          mouseLeave: mouseLeaveEventHandler
+        };
+      } else {
+        return {
+          click: clickEventHandler
+        };
+      }
     };
     this.callSettingFunction = function(functionName) {
       return this.settings[functionName](element, this.$miniTip[0]);
@@ -224,7 +239,7 @@ jQuery(function() {
       hideAnimateProperties = $.extend(hideAnimateProperties, this.getSetting('hideAnimateProperties'));
       if (this.getSetting('event') === 'hover') {
         _hover = false;
-        return this.$element.hover((function() {
+        mouseEnterEventHandler = function() {
           _hover = true;
           _this.updatePosition();
           return setTimeout(function() {
@@ -232,18 +247,21 @@ jQuery(function() {
               return _this.show();
             }
           }, _this.getSetting('delay'));
-        }), (function() {
+        };
+        mouseLeaveEventHandler = function() {
           _hover = false;
           return _this.hide();
-        }));
+        };
+        return this.$element.hover(mouseEnterEventHandler, mouseLeaveEventHandler);
       } else {
-        return this.$element.bind('click', function() {
+        clickEventHandler = function() {
           _this.updatePosition();
           _this.show();
           return window.setTimeout(function() {
             return _this.hide();
           }, _this.getSetting('delay'));
-        });
+        };
+        return this.$element.bind('click', clickEventHandler);
       }
     };
     this.init();

--- a/js/miniTip.js
+++ b/js/miniTip.js
@@ -1,7 +1,7 @@
 
 jQuery(function() {
   $.miniTip = function(element, options) {
-    var clickEventHandler, content, getArrowCss, hideAnimateProperties, miniTipCss, mouseEnterEventHandler, mouseLeaveEventHandler, setState, showAnimateProperties,
+    var activated, clickEventHandler, content, getArrowCss, hideAnimateProperties, miniTipCss, mouseEnterEventHandler, mouseLeaveEventHandler, setState, showAnimateProperties,
       _this = this;
     this.defaults = {
       position: 'top',
@@ -27,6 +27,7 @@ jQuery(function() {
     mouseEnterEventHandler = null;
     mouseLeaveEventHandler = null;
     clickEventHandler = null;
+    activated = true;
     content = '';
     miniTipCss = {
       display: 'none',
@@ -122,6 +123,9 @@ jQuery(function() {
     this.getSetting = function(settingKey) {
       return this.settings[settingKey];
     };
+    this.isActivated = function() {
+      return activated;
+    };
     this.getEventHandler = function() {
       if (this.getSetting('event') === 'hover') {
         return {
@@ -216,7 +220,7 @@ jQuery(function() {
           _hover = false;
           return _this.hide();
         };
-        return this.$element.hover(mouseEnterEventHandler, mouseLeaveEventHandler);
+        this.$element.hover(mouseEnterEventHandler, mouseLeaveEventHandler);
       } else {
         clickEventHandler = function() {
           _this.updatePosition();
@@ -225,16 +229,18 @@ jQuery(function() {
             return _this.hide();
           }, _this.getSetting('delay'));
         };
-        return this.$element.bind('click', clickEventHandler);
+        this.$element.bind('click', clickEventHandler);
       }
+      return activated = true;
     };
     this.deactivate = function() {
       if (this.getSetting('event') === 'hover') {
         this.$element.unbind('mouseenter', mouseEnterEventHandler);
-        return this.$element.unbind('mouseleave', mouseLeaveEventHandler);
+        this.$element.unbind('mouseleave', mouseLeaveEventHandler);
       } else {
-        return this.$element.unbind('click', clickEventHandler);
+        this.$element.unbind('click', clickEventHandler);
       }
+      return activated = false;
     };
     this.init = function() {
       var $miniTipArrow, $miniTipArrowShadow, arrowCss;

--- a/js/miniTip.js
+++ b/js/miniTip.js
@@ -198,9 +198,46 @@ jQuery(function() {
         });
       }
     };
-    this.init = function() {
-      var $miniTipArrow, $miniTipArrowShadow, arrowCss, _hover,
+    this.activate = function() {
+      var _hover,
         _this = this;
+      if (this.getSetting('event') === 'hover') {
+        _hover = false;
+        mouseEnterEventHandler = function() {
+          _hover = true;
+          _this.updatePosition();
+          return setTimeout(function() {
+            if (_hover) {
+              return _this.show();
+            }
+          }, _this.getSetting('delay'));
+        };
+        mouseLeaveEventHandler = function() {
+          _hover = false;
+          return _this.hide();
+        };
+        return this.$element.hover(mouseEnterEventHandler, mouseLeaveEventHandler);
+      } else {
+        clickEventHandler = function() {
+          _this.updatePosition();
+          _this.show();
+          return window.setTimeout(function() {
+            return _this.hide();
+          }, _this.getSetting('delay'));
+        };
+        return this.$element.bind('click', clickEventHandler);
+      }
+    };
+    this.deactivate = function() {
+      if (this.getSetting('event') === 'hover') {
+        this.$element.unbind('mouseenter', mouseEnterEventHandler);
+        return this.$element.unbind('mouseleave', mouseLeaveEventHandler);
+      } else {
+        return this.$element.unbind('click', clickEventHandler);
+      }
+    };
+    this.init = function() {
+      var $miniTipArrow, $miniTipArrowShadow, arrowCss;
       this.settings = $.extend({}, this.defaults, options);
       this.$miniTipContent = $('<div />', {
         'class': 'minitip-content'
@@ -237,32 +274,7 @@ jQuery(function() {
       ($(window)).resize(this.updatePosition);
       showAnimateProperties = $.extend(showAnimateProperties, this.getSetting('showAnimateProperties'));
       hideAnimateProperties = $.extend(hideAnimateProperties, this.getSetting('hideAnimateProperties'));
-      if (this.getSetting('event') === 'hover') {
-        _hover = false;
-        mouseEnterEventHandler = function() {
-          _hover = true;
-          _this.updatePosition();
-          return setTimeout(function() {
-            if (_hover) {
-              return _this.show();
-            }
-          }, _this.getSetting('delay'));
-        };
-        mouseLeaveEventHandler = function() {
-          _hover = false;
-          return _this.hide();
-        };
-        return this.$element.hover(mouseEnterEventHandler, mouseLeaveEventHandler);
-      } else {
-        clickEventHandler = function() {
-          _this.updatePosition();
-          _this.show();
-          return window.setTimeout(function() {
-            return _this.hide();
-          }, _this.getSetting('delay'));
-        };
-        return this.$element.bind('click', clickEventHandler);
-      }
+      return this.activate();
     };
     this.init();
     return this;

--- a/spec/coffeescripts/MiniTipSpec.coffee
+++ b/spec/coffeescripts/MiniTipSpec.coffee
@@ -128,6 +128,17 @@ describe 'miniTip', ->
 
         expect(plugin.show).toHaveBeenCalled()
 
+      it 'should return the mouseEnter and MouseLeave handlers', ->
+        plugin = new $.miniTip( @$element )
+        result = plugin.getEventHandler()
+        expect(result.mouseEnter).not.toBe(null)
+        expect(result.mouseLeave).not.toBe(null)
+
+      it 'should return the onClick event handler', ->
+        plugin = new $.miniTip( @$element, { event: 'click' } )
+        result = plugin.getEventHandler()
+        expect(result.click).not.toBe(null)
+
     describe 'delay', ->
       it "should add 200 milliseconds delay by default", ->
         plugin   = new $.miniTip( @$element )

--- a/spec/coffeescripts/MiniTipSpec.coffee
+++ b/spec/coffeescripts/MiniTipSpec.coffee
@@ -120,6 +120,14 @@ describe 'miniTip', ->
 
         expect(plugin.show).toHaveBeenCalled()
 
+      it 'should not show the tooltip on hover', ->
+        plugin = new $.miniTip( @$element )
+        plugin.deactivate()
+        spyOn(plugin, 'show')
+        @$element.trigger('mouseenter')
+        @clock.tick(200)
+
+        expect(plugin.show.callCount).toBe(0)
 
       it 'should show the tooltip on click', ->
         plugin = new $.miniTip( @$element, { event: 'click' } )
@@ -127,6 +135,15 @@ describe 'miniTip', ->
         @$element.trigger( 'click' )
 
         expect(plugin.show).toHaveBeenCalled()
+
+      it 'should not show the tooltip on click', ->
+        plugin = new $.miniTip( @$element, { event: 'click' } )
+        plugin.deactivate()
+        spyOn(plugin, 'show')
+        @$element.trigger('click')
+        @clock.tick(200)
+
+        expect(plugin.show.callCount).toBe(0)
 
       it 'should return the mouseEnter and MouseLeave handlers', ->
         plugin = new $.miniTip( @$element )

--- a/spec/coffeescripts/MiniTipSpec.coffee
+++ b/spec/coffeescripts/MiniTipSpec.coffee
@@ -119,6 +119,7 @@ describe 'miniTip', ->
         @clock.tick(200)
 
         expect(plugin.show).toHaveBeenCalled()
+        expect(plugin.isActivated()).toBe(true)
 
       it 'should not show the tooltip on hover', ->
         plugin = new $.miniTip( @$element )
@@ -128,6 +129,7 @@ describe 'miniTip', ->
         @clock.tick(200)
 
         expect(plugin.show.callCount).toBe(0)
+        expect(plugin.isActivated()).toBe(false)
 
       it 'should show the tooltip on click', ->
         plugin = new $.miniTip( @$element, { event: 'click' } )
@@ -135,6 +137,7 @@ describe 'miniTip', ->
         @$element.trigger( 'click' )
 
         expect(plugin.show).toHaveBeenCalled()
+        expect(plugin.isActivated()).toBe(true)
 
       it 'should not show the tooltip on click', ->
         plugin = new $.miniTip( @$element, { event: 'click' } )
@@ -144,6 +147,7 @@ describe 'miniTip', ->
         @clock.tick(200)
 
         expect(plugin.show.callCount).toBe(0)
+        expect(plugin.isActivated()).toBe(false)
 
       it 'should return the mouseEnter and MouseLeave handlers', ->
         plugin = new $.miniTip( @$element )

--- a/spec/javascripts/MiniTipSpec.js
+++ b/spec/javascripts/MiniTipSpec.js
@@ -138,7 +138,8 @@ describe('miniTip', function() {
         spyOn(plugin, 'show');
         this.$element.trigger('mouseenter');
         this.clock.tick(200);
-        return expect(plugin.show).toHaveBeenCalled();
+        expect(plugin.show).toHaveBeenCalled();
+        return expect(plugin.isActivated()).toBe(true);
       });
       it('should not show the tooltip on hover', function() {
         var plugin;
@@ -147,7 +148,8 @@ describe('miniTip', function() {
         spyOn(plugin, 'show');
         this.$element.trigger('mouseenter');
         this.clock.tick(200);
-        return expect(plugin.show.callCount).toBe(0);
+        expect(plugin.show.callCount).toBe(0);
+        return expect(plugin.isActivated()).toBe(false);
       });
       it('should show the tooltip on click', function() {
         var plugin;
@@ -156,7 +158,8 @@ describe('miniTip', function() {
         });
         spyOn(plugin, 'show');
         this.$element.trigger('click');
-        return expect(plugin.show).toHaveBeenCalled();
+        expect(plugin.show).toHaveBeenCalled();
+        return expect(plugin.isActivated()).toBe(true);
       });
       it('should not show the tooltip on click', function() {
         var plugin;
@@ -167,7 +170,8 @@ describe('miniTip', function() {
         spyOn(plugin, 'show');
         this.$element.trigger('click');
         this.clock.tick(200);
-        return expect(plugin.show.callCount).toBe(0);
+        expect(plugin.show.callCount).toBe(0);
+        return expect(plugin.isActivated()).toBe(false);
       });
       it('should return the mouseEnter and MouseLeave handlers', function() {
         var plugin, result;

--- a/spec/javascripts/MiniTipSpec.js
+++ b/spec/javascripts/MiniTipSpec.js
@@ -140,6 +140,15 @@ describe('miniTip', function() {
         this.clock.tick(200);
         return expect(plugin.show).toHaveBeenCalled();
       });
+      it('should not show the tooltip on hover', function() {
+        var plugin;
+        plugin = new $.miniTip(this.$element);
+        plugin.deactivate();
+        spyOn(plugin, 'show');
+        this.$element.trigger('mouseenter');
+        this.clock.tick(200);
+        return expect(plugin.show.callCount).toBe(0);
+      });
       it('should show the tooltip on click', function() {
         var plugin;
         plugin = new $.miniTip(this.$element, {
@@ -148,6 +157,17 @@ describe('miniTip', function() {
         spyOn(plugin, 'show');
         this.$element.trigger('click');
         return expect(plugin.show).toHaveBeenCalled();
+      });
+      it('should not show the tooltip on click', function() {
+        var plugin;
+        plugin = new $.miniTip(this.$element, {
+          event: 'click'
+        });
+        plugin.deactivate();
+        spyOn(plugin, 'show');
+        this.$element.trigger('click');
+        this.clock.tick(200);
+        return expect(plugin.show.callCount).toBe(0);
       });
       it('should return the mouseEnter and MouseLeave handlers', function() {
         var plugin, result;

--- a/spec/javascripts/MiniTipSpec.js
+++ b/spec/javascripts/MiniTipSpec.js
@@ -140,7 +140,7 @@ describe('miniTip', function() {
         this.clock.tick(200);
         return expect(plugin.show).toHaveBeenCalled();
       });
-      return it('should show the tooltip on click', function() {
+      it('should show the tooltip on click', function() {
         var plugin;
         plugin = new $.miniTip(this.$element, {
           event: 'click'
@@ -148,6 +148,21 @@ describe('miniTip', function() {
         spyOn(plugin, 'show');
         this.$element.trigger('click');
         return expect(plugin.show).toHaveBeenCalled();
+      });
+      it('should return the mouseEnter and MouseLeave handlers', function() {
+        var plugin, result;
+        plugin = new $.miniTip(this.$element);
+        result = plugin.getEventHandler();
+        expect(result.mouseEnter).not.toBe(null);
+        return expect(result.mouseLeave).not.toBe(null);
+      });
+      return it('should return the onClick event handler', function() {
+        var plugin, result;
+        plugin = new $.miniTip(this.$element, {
+          event: 'click'
+        });
+        result = plugin.getEventHandler();
+        return expect(result.click).not.toBe(null);
       });
     });
     return describe('delay', function() {


### PR DESCRIPTION
These changes add functionality to be able to deactivate the event handlers which display the tip and reactivate them when required. Existing tests pass and new tests were added.
